### PR TITLE
Prompt for domain, username, password if not specified in .env

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,12 @@ const config = require('dotenv').config().parsed
 const request = require('request')
 const moment = require('moment')
 const numeral = require('numeral')
+const readlineSync = require('readline-sync')
 
-const domain = config.DOMAIN
-const user = config.USER
+const domain = config.DOMAIN?config.DOMAIN:readlineSync.question('JIRA Domain? ')
+const user = config.USER?config.USER:readlineSync.question('JIRA Username? ')
 const username = user
-const pass = config.PASS
+const pass = config.PASS?config.PASS:readlineSync.question('JIRA Password? ', {hideEchoBack: true})
 const rate = Number(config.RATE)
 
 const api = request.defaults({

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dotenv": "^4.0.0",
     "moment": "^2.18.1",
     "numeral": "^2.0.6",
+    "readline-sync": "^1.4.7",
     "request": "^2.81.0"
   }
 }


### PR DESCRIPTION
Storing config in .env is convenient, but in some cases users make prefer to enter some or all details at invocation (especially password).

Prompt (only) for vals which are unspecified in .env